### PR TITLE
feature/python3_qt5: Add support for python 3 and Qt5 using Qt5.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ PySide client for Jean-Paul Start
 
 ![](jeanpaulstartui.jpg)
 
+### Installation 
+
+jeanpaulstartui uses Mottosso's [Qt5](https://github.com/mottosso/Qt5.py) to adapt itself to all Qt5 bindings.
+If don't have any Qt5 binding installed in your environment, you must specify the binding you want to use:
+```
+# To install with PySide2 binding
+pip install git+https://github.com/cube-creative/jeanpaulstartui.git[PySide2]
+
+# To install with PyQt5 binding
+pip install git+https://github.com/cube-creative/jeanpaulstartui.git[PyQt5]
+
+# To install without PySide2 or PyQt5 (If a Qt5 binding is already provided by the environment you are installing to ex: maya)
+pip install git+https://github.com/cube-creative/jeanpaulstartui.git
+```
+
 ### Launching
 
 Run the module `jeanpaulstartui` giving a path where to find batches, and the user tags description file

--- a/jeanpaulstartui/__main__.py
+++ b/jeanpaulstartui/__main__.py
@@ -4,7 +4,7 @@ import logging
 import getpass
 import argparse
 import pkg_resources
-from PySide.QtGui import *
+from Qt5 import QtWidgets
 from jeanpaulstartui import ROOT
 from jeanpaulstartui.launcher import Launcher
 
@@ -78,7 +78,7 @@ if __name__ == '__main__':
     except pkg_resources.DistributionNotFound:
         version = 'Not installed with pip'
 
-    app = QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     with open(ROOT + '/resources/stylesheet.css', 'r') as f_stylesheet:
         stylesheet = str(f_stylesheet.read())
     app.setStyleSheet(stylesheet)

--- a/jeanpaulstartui/view/flow_layout.py
+++ b/jeanpaulstartui/view/flow_layout.py
@@ -1,5 +1,4 @@
-from PySide.QtCore import *
-from PySide.QtGui import *
+from Qt5 import QtCore, QtWidgets
 
 
 """
@@ -8,10 +7,10 @@ https://github.com/PySide/Examples/blob/master/examples/layouts/flowlayout.py
 """
 
 
-class FlowLayout(QLayout):
+class FlowLayout(QtWidgets.QLayout):
 
     def __init__(self, parent=None, margin=0, spacing=-1):
-        QLayout.__init__(self, parent)
+        super(FlowLayout, self).__init__(parent)
         self.item_list = []
 
         if parent is None:
@@ -41,13 +40,13 @@ class FlowLayout(QLayout):
         return None
 
     def expandingDirections(self):
-        return Qt.Orientations(Qt.Orientation(0))
+        return QtCore.Qt.Orientations(QtCore.Qt.Orientation(0))
 
     def hasHeightForWidth(self):
         return True
 
     def heightForWidth(self, width):
-        height = self.do_layout(QRect(0, 0, width, 0))
+        height = self.do_layout(QtCore.QRect(0, 0, width, 0))
         return height
 
     def setGeometry(self, rect):
@@ -63,7 +62,7 @@ class FlowLayout(QLayout):
         # for item in self.item_list:
         #    size = size.expandedTo(item.minimumSize())
         # size = size + QSize(2 * self.contentsMargins().top(), 2 * self.contentsMargins().top())
-        size = QSize(2 * self.contentsMargins().top(), 2 * self.contentsMargins().top())
+        size = QtCore.QSize(2 * self.contentsMargins().top(), 2 * self.contentsMargins().top())
         return size
 
     def do_layout(self, rect, test_only=True):
@@ -73,10 +72,10 @@ class FlowLayout(QLayout):
 
         for item in self.item_list:
             widget = item.widget()
-            space_x = self.spacing() + widget.style().layoutSpacing(QSizePolicy.PushButton,
-                                                                    QSizePolicy.PushButton, Qt.Horizontal)
-            space_y = self.spacing() + widget.style().layoutSpacing(QSizePolicy.PushButton,
-                                                                    QSizePolicy.PushButton, Qt.Vertical) + 1
+            space_x = self.spacing() + widget.style().layoutSpacing(QtWidgets.QSizePolicy.PushButton,
+                                                                    QtWidgets.QSizePolicy.PushButton, QtCore.Qt.Horizontal)
+            space_y = self.spacing() + widget.style().layoutSpacing(QtWidgets.QSizePolicy.PushButton,
+                                                                    QtWidgets.QSizePolicy.PushButton, QtCore.Qt.Vertical) + 1
             next_x = x + item.sizeHint().width() + space_x
             if next_x - space_x > rect.right() and line_height > 0:
                 x = rect.x()
@@ -85,7 +84,7 @@ class FlowLayout(QLayout):
                 line_height = 0
 
             if not test_only:
-                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
+                item.setGeometry(QtCore.QRect(QtCore.QPoint(x, y), item.sizeHint()))
 
             x = next_x
 

--- a/jeanpaulstartui/view/launcher_widget.py
+++ b/jeanpaulstartui/view/launcher_widget.py
@@ -26,7 +26,7 @@ class LauncherWidget(QtWidgets.QWidget):
         
         geometry = self.settings.value('geometry', '')
         if not isinstance(geometry, QtCore.QByteArray):
-            geometry.encode("utf-8")
+            geometry = QtCore.QByteArray(geometry.encode("utf-8"))
         self.restoreGeometry(geometry)
 
         self.setMouseTracking(True)

--- a/jeanpaulstartui/view/progress_label.py
+++ b/jeanpaulstartui/view/progress_label.py
@@ -1,22 +1,21 @@
-from PySide.QtGui import *
-from PySide.QtCore import Qt
+from Qt5 import QtCore, QtWidgets, QtGui
 
 
-class ProgressLabel(QLabel):
+class ProgressLabel(QtWidgets.QLabel):
 
     def __init__(self, parent=None):
-        QLabel.__init__(self, parent=parent)
+        super(ProgressLabel, self).__init__(parent=parent)
         self._progress = 0.0
 
     def set_progress(self, value):
         self._progress = value
 
     def paintEvent(self, event):
-        painter = QPainter()
+        painter = QtGui.QPainter()
         painter.begin(self)
-        painter.setPen(Qt.NoPen)
-        painter.setBrush(QColor(61, 174, 233))
+        painter.setPen(QtCore.Qt.NoPen)
+        painter.setBrush(QtGui.QColor(61, 174, 233))
         painter.drawRect(event.rect().adjusted(0, 13, -self.width()*(1 - self._progress), 0))
         painter.end()
 
-        QLabel.paintEvent(self, event)
+        super(ProgressLabel, self).paintEvent(event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jeanpaulstart
-PySide
+jeanpaulstart @ git+https://github.com/cube-creative/jeanpaulstart.git@master#egg=jeanpaulstart
+Qt5.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jeanpaulstart @ git+https://github.com/Arubinu/jeanpaulstart.git@master#egg=jeanpaulstart
+jeanpaulstart @ git+https://github.com/Arubinu/jeanpaulstart.git@master
 Qt5.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jeanpaulstart @ git+https://github.com/cube-creative/jeanpaulstart.git@master#egg=jeanpaulstart
+jeanpaulstart @ git+https://github.com/Arubinu/jeanpaulstart.git@master#egg=jeanpaulstart
 Qt5.py

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ else:
 
 if path.isfile(_requirements_filepath):
     with open(_requirements_filepath) as requirements_file:
-        _requirements = requirements_file.readlines()
+        _requirements = [r.strip() for r in requirements_file.readlines()]
 else:
     _requirements = list()
-
+print(_requirements)
 
 setup(
     name=NAME,
@@ -38,5 +38,9 @@ setup(
     author_email=AUTHOR_EMAIL,
     packages=find_packages(exclude=['tests']),
     install_requires=_requirements,
+    extras_require={
+        "PySide2": ["PySide2"],
+        "PyQt5": ["PyQt5"]
+    },
     include_package_data=True
 )


### PR DESCRIPTION
Added support for Python >3.4
As PySide is not supportted for Python >3.4 we need to move to PySide2
I did it using Qt5.py wrapper around PySide2 and PyQt5.
By default jeanpaulstartui doesn't has dependency on PySide2 or PyQt5, to be able to use it in environment already providing theses packages (ex: maya).
PySide2 or PyQt5 are declared as extra dependencies and can be installed using pip install git+https://github.com/cube-creative/jeanpaulstartui.git[PySide2] 